### PR TITLE
Accept booleans on boolean attributes

### DIFF
--- a/lib/active_model/form/attributes.rb
+++ b/lib/active_model/form/attributes.rb
@@ -2,9 +2,9 @@ module ActiveModel
   class Form
     module BooleanAttribute
       def self.parse(v)
-        if ['1', 't', 'true', 'yes'].include? v
+        if ['1', 't', 'true', 'yes', true].include? v
           true
-        elsif ['0', 'f', 'false', 'no'].include? v
+        elsif ['0', 'f', 'false', 'no', false].include? v
           false
         elsif ['', nil].include? v
           nil

--- a/spec/boolean_attribute_form_spec.rb
+++ b/spec/boolean_attribute_form_spec.rb
@@ -21,4 +21,15 @@ describe ActiveModel::Form do
     form.checked.must_equal true
     form.not_set.must_equal nil # TODO: Should this be nil or false?
   end
+
+  it "accepts ordinary booleans" do
+    class FormWithBooleans < ActiveModel::Form
+      attribute :checked, :boolean
+      attribute :not_checked, :boolean
+    end
+
+    form = FormWithBooleans.new(:checked => true, :not_checked => false)
+    form.checked.must_equal true
+    form.not_checked.must_equal false
+  end
 end


### PR DESCRIPTION
Currently the boolean attributes fail with a parse error when set to actual true or false. This pull request fixes it.
