### PR TITLE
Add has_attribute? method to conform to AR interface

### DIFF
--- a/lib/active_model/form.rb
+++ b/lib/active_model/form.rb
@@ -40,6 +40,10 @@ module ActiveModel
       self.class.attributes[name.to_s]
     end
 
+    def has_attribute?(name)
+      self.class.attributes[name.to_s].present?
+    end
+
     def assign_attributes(new_attributes)
       return if new_attributes.blank?
       new_attributes = self.clean_attributes(new_attributes)

--- a/spec/active_record_interface_spec.rb
+++ b/spec/active_record_interface_spec.rb
@@ -1,0 +1,17 @@
+require_relative 'spec_helper'
+
+describe ActiveModel::Form do
+  it "implements the active_record interface" do
+    class Form < ActiveModel::Form
+      attribute :username, :string
+    end
+
+    form = Form.new(username: 'test')
+
+    form.column_for_attribute(:username).must_equal ActiveModel::Form::StringAttribute
+    form.column_for_attribute(:created_at).must_equal nil
+
+    form.has_attribute?(:username).must_equal true
+    form.has_attribute?(:created_at).must_equal false
+  end
+end


### PR DESCRIPTION
This PR provides support for `simple_form` 3.1.0+ which now additionally checks `has_attribute?` when determining the input type to render. See https://github.com/plataformatec/simple_form/pull/1126/files.